### PR TITLE
Correct issues with image variation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,13 @@
 # Enter the settings for your app
 # Defaults are shown below.  The BOT_KEY must be assigned
 # (All values are treated as strings, converted at time of use)
+# Required: BOT_KEY
+# Optional: SD_HOST, SD_PORT, SD_VARIATION_STRENGTH, SD_UPSCALER, 
+#           BOT_GENERATE_COMMAND, BOT_GENERATE_RANDOM_COMMAND (commands must be lower case)
 SD_HOST='localhost'
 SD_PORT=7860
 SD_VARIATION_STRENGTH='0.065'
 SD_UPSCALER='R-ESRGAN 4x+'
-BOT_KEY=
+BOT_KEY=<replace_with_your_key>
+BOT_GENERATE_COMMAND='generate'
+BOT_GENERATE_RANDOM_COMMAND='generate_random'

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The bot settings are defined in:
 - `.env.deploy` : settings for deployed bot
 (copy the `.env.template` file for initial definition)
 
-Most default settings can be kept, but you **must specify** the `BOT_KEY` which you obtain from the discord bot app setup. (You first have to create a discord bot at discord.com/developers/ but I won't explain this here. Just make sure that the bot has access to commands and can type messages / embed things. Don't forget to add the bot to your discord using the generated link in the devoloper portal with the correct rights, but I think that should be clear.  General instructions can be found on [RealPython: how to make a discort bot](https://realpython.com/how-to-make-a-discord-bot-python/))
+Most default settings can be kept, but you **must specify** the `BOT_KEY` which you obtain from the discord bot app setup. (You first have to create a discord bot at discord.com/developers/ but I won't explain this here. Just make sure that the bot has access to commands and can type messages / embed things. Don't forget to add the bot to your discord using the generated link in the devoloper portal with the correct rights, but I think that should be clear.  General instructions can be found on [RealPython: how to make a Discord bot](https://realpython.com/how-to-make-a-discord-bot-python/))
 
-Finally, start the bot using `python3 bot.py` - after this you can use the bot using /generate or /generate_random. 
+Finally, start the bot using `python3 bot.py` - after this you can use the bot using `/generate` or `/generate_random` (alternate command names can be specified in `.env.deploy` file). 
 
-To change / add styles, add the style to the command array in bot.py and add the preprompt, afterprompt and negative_prompt to prompts.py. There you can also find the prompts for the other styles.
+To change / add styles, add the style to the command array in bot.py and add the preprompt, afterprompt and negative_prompt to `prompts.py`. There you can also find the prompts for the other styles.
 
 Since this is my first Discord bot, things could probably be solved in a simpler/better way. So feel free to submit a pull request to fix some issues.
 

--- a/bot.py
+++ b/bot.py
@@ -166,7 +166,6 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
     total_requests = total_requests + 1
     global webui_url
     global variation_strength
-    currentTime = datetime.now()   
     width, height = make_orientation(orientation)
     prompt, negativeprompt = make_prompt(prompt, style, original_negativeprompt)
     if variation:
@@ -201,7 +200,7 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
         image_id = ''.join(random.choice(characters) for i in range(24))
         file_path = f"GeneratedImages/{image_id}.png"
         image.save(file_path, pnginfo=pnginfo)
-        print ("Generated Image:", file_path)
+        print (f"{datetime.now().strftime('%x %X')} Generated Image:", file_path)
         print (total_requests)
         with open('current_requests.txt', 'w') as file:
             file.write(str(total_requests))
@@ -230,7 +229,7 @@ async def upscale(image):
     file_path = file_path.replace('.png', '')
     file_path = f"{file_path}-upscaled.png"
     image_upscaled.save(file_path)
-    print ("Upscaled Image:", file_path)
+    print (f"{datetime.now().strftime('%x %X')} Upscaled Image:", file_path)
     print (total_requests)
     with open('current_requests.txt', 'w') as file:
         file.write(str(total_requests))

--- a/bot.py
+++ b/bot.py
@@ -30,8 +30,8 @@ generate_random_command = os.environ.get('BOT_GENERATE_RANDOM_COMMAND', 'generat
 
 # Apply Settings:
 webui_url = f"http://{SD_HOST}:{SD_PORT}"   # URL/Port of the A1111 webui
-upscaler_model = SD_UPSCALER                # How much should the varied image varie from the original?
-variation_strength = SD_VARIATION_STRENGTH  # Name of the upscaler. I recommend "4x_NMKD-Siax_200k" but you have to download it manually.
+upscaler_model = SD_UPSCALER                # Name of the upscaler. I recommend "4x_NMKD-Siax_200k" but you have to download it manually.
+variation_strength = SD_VARIATION_STRENGTH  # How much should the varied image vary from the original?
 discord_bot_key = BOT_KEY                   # Set this to the discord bot key from the bot you created on the discord devoloper page.
 
 # upfront checks
@@ -136,7 +136,14 @@ class MyView(discord.ui.View):
         variation_image, image_id = await imagegen(self.prompt, self.style, self.orientation, self.negative_prompt, self.seed, variation=True)
         with open(variation_image, 'rb') as f:
             image_bytes = f.read()
-        message = await interaction.followup.send(f"Varied This Generation:", file=discord.File(io.BytesIO(image_bytes), f'{self.prompt}-{self.style}-{image_id}-varied.png'), view=UpscaleOnlyView(f"GeneratedImages/{image_id}.png"))
+        message = await interaction.followup.send(
+            f"Varied This Generation:", 
+            file=discord.File(
+                io.BytesIO(image_bytes), 
+                f'{self.prompt}-{self.style}-{image_id}-varied.png'
+            ), 
+            view=UpscaleOnlyView(f"GeneratedImages/{image_id}.png")
+        )
         
     @discord.ui.button(label="Variation R", row=1, style=discord.ButtonStyle.primary, emoji="🌱") 
     async def button_variation2(self, button, interaction):
@@ -144,7 +151,14 @@ class MyView(discord.ui.View):
         variation_image, image_id = await imagegen(self.prompt, self.style, self.orientation, self.negative_prompt, self.seed1, variation=True)
         with open(variation_image, 'rb') as f:
             image_bytes = f.read()
-        message = await interaction.followup.send(f"Varied This Generation:", file=discord.File(io.BytesIO(image_bytes), f'{self.prompt}-{self.style}-{image_id}-varied.png'), view=UpscaleOnlyView(f"GeneratedImages/{image_id}.png"))
+        message = await interaction.followup.send(
+            f"Varied This Generation:", 
+            file=discord.File(
+                io.BytesIO(image_bytes), 
+                f'{self.prompt}-{self.style}-{image_id}-varied.png'
+            ), 
+            view=UpscaleOnlyView(f"GeneratedImages/{image_id}.png")
+        )
         
     @discord.ui.button(label="Retry", row=2, style=discord.ButtonStyle.primary, emoji="🔄")
     async def button_retry(self, button, interaction):
@@ -155,7 +169,11 @@ class MyView(discord.ui.View):
             discord.File(retried_image),
             discord.File(retried_image2),
         ]
-        message = await interaction.followup.send(f"Retried These Generations:", files=retried_images, view=UpscaleOnlyView2(f"GeneratedImages/{image_id}.png", f"GeneratedImages/{image_id2}.png"))
+        message = await interaction.followup.send(
+            f"Retried These Generations:", 
+            files=retried_images, 
+            view=UpscaleOnlyView2(f"GeneratedImages/{image_id}.png", f"GeneratedImages/{image_id2}.png")
+        )
         
 def random_seed():
     return random.randint(0, 1000000000000)
@@ -169,9 +187,9 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
     width, height = make_orientation(orientation)
     prompt, negativeprompt = make_prompt(prompt, style, original_negativeprompt)
     if variation:
-        variation_strength = variation_strength
+        var_strength = variation_strength
     else:
-        variation_strength = 0
+        var_strength = 0
     payload = {
         "prompt": prompt,
         'negative_prompt': negativeprompt,
@@ -183,7 +201,7 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
         'seed': seed,
         'tiling': False,
         'restore_faces': True,
-        'subseed_strength': variation_strength
+        'subseed_strength': var_strength
     }
     response = requests.post(url=f'{webui_url}/sdapi/v1/txt2img', json=payload)
     r = response.json()  
@@ -197,11 +215,10 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
         pnginfo = PngImagePlugin.PngInfo()
         pnginfo.add_text("parameters", response2.json().get("info"))
         global characters
-        image_id = ''.join(random.choice(characters) for i in range(24))
+        image_id = ''.join(random.choice(characters) for _ in range(24))
         file_path = f"GeneratedImages/{image_id}.png"
         image.save(file_path, pnginfo=pnginfo)
-        print (f"{datetime.now().strftime('%x %X')} Generated Image:", file_path)
-        print (total_requests)
+        print (f"{datetime.now().strftime('%x %X')} Generated Image {total_requests}:", file_path)
         with open('current_requests.txt', 'w') as file:
             file.write(str(total_requests))
         return file_path, image_id
@@ -229,8 +246,7 @@ async def upscale(image):
     file_path = file_path.replace('.png', '')
     file_path = f"{file_path}-upscaled.png"
     image_upscaled.save(file_path)
-    print (f"{datetime.now().strftime('%x %X')} Upscaled Image:", file_path)
-    print (total_requests)
+    print (f"{datetime.now().strftime('%x %X')} Upscaled Image {total_requests}:", file_path)
     with open('current_requests.txt', 'w') as file:
         file.write(str(total_requests))
     return file_path
@@ -312,10 +328,10 @@ async def generate(
     if len(title_prompt) > 150:
         title_prompt = title_prompt[:150] + "..."
     embed = discord.Embed(
-            title="Prompt: " + title_prompt,
-            description=f"Style: `{style}`\nOrientation: `{orientation}`\nSeed (Left): `{seed}`\nSeed (Right): `{seed2}`\nNegative Prompt: `{negative_prompt}`\nTotal generated images: `{total_requests}`",
-            color=discord.Colour.blurple(),
-        )
+        title="Prompt: " + title_prompt,
+        description=f"Style: `{style}`\nOrientation: `{orientation}`\nSeed (Left): `{seed}`\nSeed (Right): `{seed2}`\nNegative Prompt: `{negative_prompt}`\nTotal generated images: `{total_requests}`",
+        color=discord.Colour.blurple(),
+    )
     await ctx.respond("Generating 2 images...", ephemeral=True, delete_after=3)  
     generated_image, image_id = await imagegen(prompt, style, orientation, negative_prompt, seed)
     generated_image2, image_id2 = await imagegen(prompt, style, orientation, negative_prompt, seed2)

--- a/bot.py
+++ b/bot.py
@@ -34,18 +34,30 @@ upscaler_model = SD_UPSCALER                # Name of the upscaler. I recommend 
 variation_strength = SD_VARIATION_STRENGTH  # How much should the varied image vary from the original?
 discord_bot_key = BOT_KEY                   # Set this to the discord bot key from the bot you created on the discord devoloper page.
 
+# helper functions
+def random_seed():
+    return random.randint(0, 1_000_000_000_000)
+
+def current_time_str():
+    return datetime.now().strftime('%x %X')
+
 # upfront checks
 assert BOT_KEY is not None, "Invalid specification: BOT_KEY must be defined"
 try:
     res = requests.get(webui_url)
+    if res.status_code == 200:
+        print(f"{current_time_str()}: Connected to SD host on URL: {webui_url}")
+    else:
+        print(f"{current_time_str()}: Did not receive correct response from SD host: {webui_url}\nResponse code={res.status_code}")
+        sys.exit(1) 
 except requests.ConnectionError as e:
-    print("Failed to connect to SD host; possibly incorrect URL:\n", e) 
+    print(f"{current_time_str()}: Failed to connect to SD host; possibly incorrect URL:\n", e) 
     sys.exit(1) 
 
 # Initialize
 bot = discord.Bot()
 os.system('clear')
-print ("Bot is running")
+print (f"{current_time_str()}: Bot is running")
 characters = string.ascii_letters + string.digits
 tokenizer = GPT2Tokenizer.from_pretrained('distilgpt2')
 tokenizer.add_special_tokens({'pad_token': '[PAD]'})
@@ -175,9 +187,6 @@ class MyView(discord.ui.View):
             view=UpscaleOnlyView2(f"GeneratedImages/{image_id}.png", f"GeneratedImages/{image_id2}.png")
         )
         
-def random_seed():
-    return random.randint(0, 1000000000000)
-
 # This is the function the generate the image and send the request to A1111.
 async def imagegen(prompt, style, orientation, original_negativeprompt, seed, variation=False):
     global total_requests
@@ -218,7 +227,7 @@ async def imagegen(prompt, style, orientation, original_negativeprompt, seed, va
         image_id = ''.join(random.choice(characters) for _ in range(24))
         file_path = f"GeneratedImages/{image_id}.png"
         image.save(file_path, pnginfo=pnginfo)
-        print (f"{datetime.now().strftime('%x %X')} Generated Image {total_requests}:", file_path)
+        print (f"{current_time_str()}: Generated Image {total_requests}:", file_path)
         with open('current_requests.txt', 'w') as file:
             file.write(str(total_requests))
         return file_path, image_id
@@ -246,7 +255,7 @@ async def upscale(image):
     file_path = file_path.replace('.png', '')
     file_path = f"{file_path}-upscaled.png"
     image_upscaled.save(file_path)
-    print (f"{datetime.now().strftime('%x %X')} Upscaled Image {total_requests}:", file_path)
+    print (f"{current_time_str()}: Upscaled Image {total_requests}:", file_path)
     with open('current_requests.txt', 'w') as file:
         file.write(str(total_requests))
     return file_path


### PR DESCRIPTION
This PR is to correct the issues seen with "Variation L/R" buttons (they did not do anything before).  Other changes for code cleanup and logging:
- corrected issue with `variation_strength` being set to 0 after first images (duplicate variable name overwrote the specified value); Now small variations are produced based upon the specified strength (in `.env` file)
- added ability to specify different slash command for `/generate` and `/generate_random` (see `.env` file)
- corrected issue that specified upscaler was ignored.  Now can be specified and a check is made to make sure it exists
- cleaned up code with function for seed and current time
- improved logging to include time stamp; reduced log to 1 line per image generation
- added further notes/corrections to README.md